### PR TITLE
Launching executable located outside of $PATH requires "./" on Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ update data source or contribute in any other way, you will probably want to reb
 
 ```bash
 $ composer install --dev
-$ console build
+$ ./console build
 ```
 
 Provinces


### PR DESCRIPTION
$ console doesn't work
$ ./console does
