### PR TITLE
updated country name of Swaziland

### DIFF
--- a/data/af/country.csv
+++ b/data/af/country.csv
@@ -219,7 +219,7 @@ KR,Suid-Korea
 SS,Suid-Soedan
 SR,Suriname
 SJ,"Svalbard en Jan Mayen"
-SZ,Swaziland
+SZ,Eswatini
 SE,Swede
 CH,Switserland
 TJ,Tadjikistan


### PR DESCRIPTION
Swaziland changed its name in April 2018. Sources: https://en.wikipedia.org/wiki/Timeline_of_historical_geopolitical_changes and https://www.iso.org/obp/ui/#iso:code:3166:SZ